### PR TITLE
bugfix: image in label transform wrong

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ const extract = (src, __webpack_public_path__) => {
 };
 
 const defaultMinimizeConf = {
-	html5: false,
+	html5: true,
 	removeComments: true,
 	removeCommentsFromCDATA: true,
 	removeCDATASectionsFromCDATA: true,


### PR DESCRIPTION
the wrong transformation: 
```
<label wx:if="{{activity.qrcode_url}}" bindtap="showQrCode" class="button small yellow">
      <image class="btn-img" src="./image/icon_redpacket.png"/>更多红包
</label>
```
to 
```
<image class="btn-img" src="./image/icon_redpacket.png"/>更多红包
<label wx:if="{{activity.qrcode_url}}" bindtap="showQrCode" class="button small yellow"></label>
```