### PR TITLE
upgrade loader-utils to handle `cloud://...` url

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "licenses": "MIT",
   "dependencies": {
     "html-minifier": "^3.5.6",
-    "loader-utils": "^1.1.0",
+    "loader-utils": "^1.2.3",
     "sax": "^1.2.2"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,14 @@ describe('wxml-loader', async () => {
 		expect(getCompiledRes()).toBe('<image src="./images/image.gif" />');
 	});
 
+	test('should enforceRelativePath ignore url with procotol', async () => {
+		const code = '<image src="cloud://m.baidu.com/fixture.gif" />';
+		await compile(code, { enforceRelativePath: true });
+		expect(getCompiledRes()).toBe(
+			'<image src="cloud://m.baidu.com/fixture.gif" />',
+		);
+	});
+
 	test('should work if publicPath starts with protocol', async () => {
 		const code = '<image src="./fixture.gif" />';
 		await compile(code, { globalPublicPath: 'http://m.baidu.com/' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,6 +1018,10 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "http://registry.npm.taobao.org/big.js/download/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+
 binary-extensions@^1.0.0:
   version "1.7.0"
   resolved "http://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.7.0.tgz#6c1610db163abfb34edfe42fa423343a1e01185d"
@@ -3546,6 +3550,12 @@ json5@^0.5.0:
   version "0.5.0"
   resolved "http://registry.npm.taobao.org/json5/download/json5-0.5.0.tgz#9b20715b026cbe3778fd769edccd822d8332a5b2"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "http://registry.npm.taobao.org/jsonify/download/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3649,6 +3659,14 @@ loader-utils@^1.0.2, loader-utils@^1.1.0:
     big.js "^3.1.3"
     emojis-list "^2.0.0"
     json5 "^0.5.0"
+
+loader-utils@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
云开发存储的文件可以在 wxml 里用的组件以 `cloud://...` 为地址使用：

https://developers.weixin.qq.com/miniprogram/dev/wxcloud/guide/storage.html

例如：

```html
<image src="cloud://foo.bar/fixture.gif" />
```
